### PR TITLE
glib/gst-plugins-bad: Don't pull in dtls/datagram patches

### DIFF
--- a/dependencies/build-glib-networking.sh
+++ b/dependencies/build-glib-networking.sh
@@ -20,21 +20,6 @@ install_sources() {
         cd $BUILD_DIR
         git reset --hard $GLIB_NETWORKING_VERSION
 
-        # dtls
-        git remote add tester git://git.collabora.co.uk/git/user/tester/glib-networking.git
-        git fetch tester dtls
-        git cherry-pick 6be4711c22053a0be84c19b0ad1e7020dc2793d4
-        git cherry-pick b2b006a81ece97c2331e46668cc33b56e63c97b1
-        git cherry-pick a0efd5a2a8854f9abdf37673f00f3e16795ff627
-        git cherry-pick 97aa561e99277c1e0586f1f20e2a29e8fe03f9ae
-        git checkout HEAD^ configure.ac
-        git add configure.ac
-        git commit --amend -C HEAD
-        git cherry-pick fb4fb47edc80b3c504dab2b9a78140b63f216afe
-        git cherry-pick f549a05ba3f985596d1cf0ccd7fd9fe6af350224
-        git cherry-pick fc943ddab73ba6033a37af914a0757bd0c83ad90
-        git cherry-pick a384bfa57ed58882658085288cc48d4aa08efd09
-
         # static modules
         git remote add gst-sdk git://anongit.freedesktop.org/gstreamer-sdk/glib-networking
         git fetch gst-sdk

--- a/dependencies/build-glib.sh
+++ b/dependencies/build-glib.sh
@@ -22,16 +22,6 @@ install_sources(){
     (
         cd $BUILD_DIR
         git reset --hard sdk-release-sdk-2013.6
-
-        # datagram iostreams, dtls
-        git remote add tester git://git.collabora.co.uk/git/user/tester/glib.git
-        git fetch tester datagram
-        git cherry-pick e1fdd59f08b3072464b5374b62146fd69014ef77
-        git cherry-pick 01233adcbbbe8ec5bceddff15e53474e35b8e57b
-        git cherry-pick 1b9649a845276ef687655f6d4f8f4b646e910c00
-        git cherry-pick 3f8fa3a610cb618992d7578122c6574a9eab1ac9
-        git cherry-pick 9fba9add9a3b17de5460379396005152444eea75
-        git cherry-pick d68ff5b869ec19e0e49c4509cbd3a5c46d8b91ce
     )
 }
 

--- a/dependencies/build-gst-plugins-bad.sh
+++ b/dependencies/build-gst-plugins-bad.sh
@@ -23,13 +23,6 @@ install_sources() {
     (
         cd $BUILD_DIR
         git reset --hard $GST_VERSION
-
-        # dtls plugin
-        git remote add tester git://git.collabora.co.uk/git/user/tester/gst-plugins-bad.git
-        git fetch tester dtls
-        git cherry-pick -Xtheirs 07fc98c765117cc442dee412a3cd08cb6235a743
-        git cherry-pick 0409014cd264fc887f951172b7af7f7b5abf680b
-        git cherry-pick b65443e0bdcaf3edae219b7b8cdbd6b1997c6fdc
     )
 }
 


### PR DESCRIPTION
We don't actually use those patches, and the code will likely change a lot
before it gets merged upstream.

See discussion on: https://bugzilla.gnome.org/show_bug.cgi?id=697907
