### PR TITLE
build-gst-plugins-bad: Removed ext/dtls make && make install

### DIFF
--- a/dependencies/build-gst-plugins-bad.sh
+++ b/dependencies/build-gst-plugins-bad.sh
@@ -141,8 +141,7 @@ build() {
 	    echo -e "all:\n\ninstall:\n" > docs/Makefile
 	    echo -e "all:\n\ninstall:\n" > tests/Makefile
 	} &&
-	ERROR_CFLAGS="" make && make install && \
-	cd ext/dtls && make && make install
+	ERROR_CFLAGS="" make && make install
 	)
 }
 


### PR DESCRIPTION
Since the we're no longer fetching the dtls patches this line should be removed
