### PR TITLE
build fails on stock kubuntu 64-bit without the gperf package

### DIFF
--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -8,7 +8,7 @@ function install_dependencies {
     target=$2
     if [[ "$target" == "linux" ]]; then
         echo "Using \"sudo -E apt-get\" to install needed dependencies."
-        sudo -E apt-get install g++ curl zlib1g-dev libpulse-dev libv4l-dev libxv-dev libgl1-mesa-dev libglu1-mesa-dev libxml-perl openjade xsltproc python-dev python2.7-dev openjdk-7-jdk subversion git
+        sudo -E apt-get install g++ curl zlib1g-dev libpulse-dev libv4l-dev libxv-dev libgl1-mesa-dev libglu1-mesa-dev libxml-perl openjade xsltproc python-dev python2.7-dev openjdk-7-jdk subversion git gperf
     fi
 }
 


### PR DESCRIPTION
while running scripts/dependencies/build-all.sh

```
configure: error: You need the 'gperf' hash function generator to compile WebKit
```
