### PR TITLE
Removed non-breaking whitespace -- those can hurt people

### DIFF
--- a/bootstrap/build-xz.sh
+++ b/bootstrap/build-xz.sh
@@ -53,7 +53,7 @@ build() {
 
     # build xz
     pushd xz-$XZ_VERSION > /dev/null
-    ./configure --prefix=$PREFIX && make && make install || die "$0 -- Could not build xz."
+    ./configure --prefix=$PREFIX && make && make install || die "$0 -- Could not build xz."
     popd > /dev/null
 
     popd > /dev/null


### PR DESCRIPTION
Change-Id: Icbbd67c3b79249b30044583ce277e8aed3940d53

This one contained a c2a0 byte sequence before die. Lync adds those sometimes to make fun of people.
