### PR TITLE
bootstrap: Update pygobject to 3.10.2

### DIFF
--- a/bootstrap/build-pygobject.sh
+++ b/bootstrap/build-pygobject.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PYGOBJECT_VERSION=3.4.2
+PYGOBJECT_VERSION=3.10.2
 
 BUILD_DIR=pygobject
 SCRIPT_DIR=../engine


### PR DESCRIPTION
We were using 3.4.2 which is ages old. Updating to newer than 3.10.x would
require updating GLib and probably other things as well. We can look into that
when there is time.
