### PR TITLE
Patch glib to set thread names on OS X and iOS

### DIFF
--- a/dependencies/build-glib.sh
+++ b/dependencies/build-glib.sh
@@ -25,7 +25,7 @@ install_sources(){
     )
 }
 
-patch_sources() {
+patch_sources(){
     local arch=$1
     local target_triple=$2
     local home=$(pwd)
@@ -33,108 +33,108 @@ patch_sources() {
     echo "Patch sources for ${target_triple}"
 
     (
-	cd $BUILD_DIR
+        cd $BUILD_DIR
         git clean -xdf
         git reset --hard HEAD
-	git checkout $target_triple || {
-	    echo "ERROR: Could not checkout ${target_triple} in $(pwd)"
-	    exit 1
-	}
+        git checkout $target_triple || {
+            echo "ERROR: Could not checkout ${target_triple} in $(pwd)"
+            exit 1
+        }
 
- 	if [[ $target_triple == "arm-linux-androideabi" ]]; then
- 	    cp ${home}/config.{guess,sub} .
- 	    git commit --no-verify -a -m "Patched glib sources for android and updated config.{guess,sub}"
- 	fi
- 	)
-
+        if [[ $target_triple == "arm-linux-androideabi" ]]; then
+            cp ${home}/config.{guess,sub} .
+            git commit --no-verify -a -m "Patched glib sources for android and updated config.{guess,sub}"
+        fi
+    )
 }
+
 build(){
     local arch=$1
     local target_triple=$2
     local home=$(pwd)
 
     (
-	cd $BUILD_DIR
-        git clean -xdf
-        git reset --hard HEAD
-	git checkout $target_triple || {
-	    echo "ERROR: Could not checkout ${target_triple} in ${home}"
-	    exit 1
-	}
-	)
+        cd $BUILD_DIR
+            git clean -xdf
+            git reset --hard HEAD
+        git checkout $target_triple || {
+            echo "ERROR: Could not checkout ${target_triple} in ${home}"
+            exit 1
+        }
+    )
 
 
     (
-	cd ${builddir}
+        cd ${builddir}
 
-	export LDFLAGS="-L${installdir}/../gettext-${GETTEXT_VERSION}/lib"
-	export LIBFFI_CFLAGS="-I${installdir}/../libffi/lib/libffi-${LIBFFI_VERSION}/include"
-	export LIBFFI_LIBS="-L${installdir}/../libffi/lib -lffi"
-	export CPPFLAGS="$PLATFORM_CFLAGS -I${installdir}/../gettext-${GETTEXT_VERSION}/include"
-	export CFLAGS="$CFLAGS $PLATFORM_CFLAGS"
-	export CXXFLAGS="$CFLAGS"
-	if [[ ${target_triple} =~ (i386|arm)"-apple-darwin10" ]]; then
-	    export LDFLAGS="$LDFLAGS -L${PLATFORM_IOS_SDK}/usr/lib -framework Foundation"
-	    export ZLIB_CFLAGS="-I${installdir}/../zlib-${ZLIB_VERSION}/include"
-	    export ZLIB_LIBS="-L${installdir}/../zlib-${ZLIB_VERSION}/lib -lz"
-	    export LIBS="-lintl -liconv -lresolv"
+        export LDFLAGS="-L${installdir}/../gettext-${GETTEXT_VERSION}/lib"
+        export LIBFFI_CFLAGS="-I${installdir}/../libffi/lib/libffi-${LIBFFI_VERSION}/include"
+        export LIBFFI_LIBS="-L${installdir}/../libffi/lib -lffi"
+        export CPPFLAGS="$PLATFORM_CFLAGS -I${installdir}/../gettext-${GETTEXT_VERSION}/include"
+        export CFLAGS="$CFLAGS $PLATFORM_CFLAGS"
+        export CXXFLAGS="$CFLAGS"
+        if [[ ${target_triple} =~ (i386|arm)"-apple-darwin10" ]]; then
+            export LDFLAGS="$LDFLAGS -L${PLATFORM_IOS_SDK}/usr/lib -framework Foundation"
+            export ZLIB_CFLAGS="-I${installdir}/../zlib-${ZLIB_VERSION}/include"
+            export ZLIB_LIBS="-L${installdir}/../zlib-${ZLIB_VERSION}/lib -lz"
+            export LIBS="-lintl -liconv -lresolv"
 
-	    $CC $CFLAGS -c -o ${builddir}/my_environ.o ${home}/my_environ.c
-	    $CC $CFLAGS -c -o ${builddir}/my_stat.o ${home}/my_stat.c
-	    export CPPFLAGS="$CPPFLAGS -I${PLATFORM_IOS_SDK}/usr/include"
+            $CC $CFLAGS -c -o ${builddir}/my_environ.o ${home}/my_environ.c
+            $CC $CFLAGS -c -o ${builddir}/my_stat.o ${home}/my_stat.c
+            export CPPFLAGS="$CPPFLAGS -I${PLATFORM_IOS_SDK}/usr/include"
 
-	    local extra_configure_flags="--with-libiconv=native --disable-dtrace" # i386 builds detects dtrace but cannot use it.
-	    # For configure since it can't test this
-	    export glib_cv_stack_grows=no
-	    export glib_cv_uscore=no
-	    export ac_cv_func_posix_getgrgid_r=yes
-	    export ac_cv_func_posix_getpwuid_r=yes
-            export ac_cv_func_memmove=yes
-            export ac_cv_func__NSGetEnviron=no
-            export ac_cv_sizeof___int64=8
-
-        if [[ $target_triple == "arm-apple-darwin10" ]]; then
-            export LDFLAGS="$LDFLAGS ${builddir}/my_environ.o ${builddir}/my_stat.o"
-            export CPPFLAGS="$CPPFLAGS -Denviron=my_environ -Dstat=my_stat"
-        fi
-	elif [[ $target_triple == "arm-linux-androideabi" ]]; then
-	    export LDFLAGS="$LDFLAGS -L${installdir}/../libiconv-${LIBICONV_VERSION}/lib"
-	    export CPPFLAGS="$CPPFLAGS -I${installdir}/../libiconv-${LIBICONV_VERSION}/include"
-	    export GLIB_GENMARSHAL="${BUILD_DIR}/glib-genmarshal-wrapper.sh"
-	    export LIBS="-lintl -liconv"
-	    local extra_configure_flags="--with-libiconv=gnu --disable-gtk-doc --disable-maintainer-mode --disable-silent-rules"
+            local extra_configure_flags="--with-libiconv=native --disable-dtrace" # i386 builds detects dtrace but cannot use it.
+            # For configure since it can't test this
             export glib_cv_stack_grows=no
             export glib_cv_uscore=no
-            export ac_cv_func_posix_getpwuid_r=no
-            export ac_cv_func_nonposix_getpwuid_r=no
-            export ac_cv_func_posix_getgrgid_r=no
-            export ac_cv_func_nonposix_getgrgid_r=no
+            export ac_cv_func_posix_getgrgid_r=yes
+            export ac_cv_func_posix_getpwuid_r=yes
+                export ac_cv_func_memmove=yes
+                export ac_cv_func__NSGetEnviron=no
+                export ac_cv_sizeof___int64=8
 
-        elif [[ $target_triple == "x86_64-apple-darwin" ]]; then
-            export LDFLAGS="$LDFLAGS -framework Foundation"
-            export LIBS="-lintl -liconv -lresolv"
-	    local extra_configure_flags="--disable-carbon -disable-dtrace"
-    elif [[ $target_triple == "x86_64-unknown-linux" ]]; then
-        export ZLIB_CFLAGS="-I${installdir}/../zlib-${ZLIB_VERSION}/include"
-        export ZLIB_LIBS="-L${installdir}/../zlib-${ZLIB_VERSION}/lib -lz"
-        local extra_configure_flags="--disable-selinux"
-	fi
+            if [[ $target_triple == "arm-apple-darwin10" ]]; then
+                export LDFLAGS="$LDFLAGS ${builddir}/my_environ.o ${builddir}/my_stat.o"
+                export CPPFLAGS="$CPPFLAGS -Denviron=my_environ -Dstat=my_stat"
+            fi
+        elif [[ $target_triple == "arm-linux-androideabi" ]]; then
+            export LDFLAGS="$LDFLAGS -L${installdir}/../libiconv-${LIBICONV_VERSION}/lib"
+            export CPPFLAGS="$CPPFLAGS -I${installdir}/../libiconv-${LIBICONV_VERSION}/include"
+            export GLIB_GENMARSHAL="${BUILD_DIR}/glib-genmarshal-wrapper.sh"
+            export LIBS="-lintl -liconv"
+            local extra_configure_flags="--with-libiconv=gnu --disable-gtk-doc --disable-maintainer-mode --disable-silent-rules"
+                export glib_cv_stack_grows=no
+                export glib_cv_uscore=no
+                export ac_cv_func_posix_getpwuid_r=no
+                export ac_cv_func_nonposix_getpwuid_r=no
+                export ac_cv_func_posix_getgrgid_r=no
+                export ac_cv_func_nonposix_getgrgid_r=no
 
-	${home}/$BUILD_DIR/autogen.sh \
-	    --prefix=${installdir} \
-	    --host=${target_triple} \
-	    --enable-static \
-	    --disable-shared \
-	    --enable-debug=no \
-            --disable-compile-warnings \
-            --disable-libelf \
-            --disable-dependency-tracking \
-            --disable-dtrace \
-            --disable-modular-tests ${extra_configure_flags} \
-	    && { \
-            echo -e "all:\n\ninstall:\n" > docs/Makefile
-            echo -e "all:\n\ninstall:\n" > glib/tests/Makefile
-        } || exit 1
+            elif [[ $target_triple == "x86_64-apple-darwin" ]]; then
+                export LDFLAGS="$LDFLAGS -framework Foundation"
+                export LIBS="-lintl -liconv -lresolv"
+            local extra_configure_flags="--disable-carbon -disable-dtrace"
+        elif [[ $target_triple == "x86_64-unknown-linux" ]]; then
+            export ZLIB_CFLAGS="-I${installdir}/../zlib-${ZLIB_VERSION}/include"
+            export ZLIB_LIBS="-L${installdir}/../zlib-${ZLIB_VERSION}/lib -lz"
+            local extra_configure_flags="--disable-selinux"
+        fi
+
+        ${home}/$BUILD_DIR/autogen.sh \
+            --prefix=${installdir} \
+            --host=${target_triple} \
+            --enable-static \
+            --disable-shared \
+            --enable-debug=no \
+                --disable-compile-warnings \
+                --disable-libelf \
+                --disable-dependency-tracking \
+                --disable-dtrace \
+                --disable-modular-tests ${extra_configure_flags} \
+            && { \
+                echo -e "all:\n\ninstall:\n" > docs/Makefile
+                echo -e "all:\n\ninstall:\n" > glib/tests/Makefile
+            } || exit 1
 
         pushd ${builddir}/gio
         make gioenumtypes.c
@@ -144,7 +144,7 @@ build(){
         popd
 
         make && make install
-	)
+    )
 }
 
 dependencies(){

--- a/dependencies/build-glib.sh
+++ b/dependencies/build-glib.sh
@@ -40,6 +40,11 @@ patch_sources(){
             echo "ERROR: Could not checkout ${target_triple} in $(pwd)"
             exit 1
         }
+        git apply --index ../glib-osx-thread-set-name.patch || {
+            echo "ERROR: Could not patch ${target_triple} in $(pwd)"
+            exit 1
+        }
+        git commit --no-verify -m "Implement g_system_thread_set_name on OS X and iOS"
 
         if [[ $target_triple == "arm-linux-androideabi" ]]; then
             cp ${home}/config.{guess,sub} .

--- a/dependencies/build-glib.sh
+++ b/dependencies/build-glib.sh
@@ -125,12 +125,20 @@ build(){
             local extra_configure_flags="--disable-selinux"
         fi
 
+        extra_configure_flags+=" --enable-debug="
+        [[ $do_release == yes ]] && {
+            extra_configure_flags+="no"
+        } || {
+            extra_configure_flags+="yes"
+            # Our CFLAGS export overrides autogen.sh's, so we must add -g ourselves
+            export CFLAGS="$CFLAGS -g"
+        }
+
         ${home}/$BUILD_DIR/autogen.sh \
             --prefix=${installdir} \
             --host=${target_triple} \
             --enable-static \
             --disable-shared \
-            --enable-debug=no \
                 --disable-compile-warnings \
                 --disable-libelf \
                 --disable-dependency-tracking \

--- a/dependencies/glib-osx-thread-set-name.patch
+++ b/dependencies/glib-osx-thread-set-name.patch
@@ -1,0 +1,40 @@
+diff --git a/configure.ac b/configure.ac
+index b07c98c..aac4547 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2447,6 +2447,16 @@ AS_IF([ test x"$have_threads" = xposix], [
+              AC_DEFINE(HAVE_PTHREAD_CONDATTR_SETCLOCK,1,
+                 [Have function pthread_condattr_setclock])],
+             [AC_MSG_RESULT(no)])
++        dnl Sets thread names on OS X 10.6, iOS 3.2 (and higher)
++        AC_MSG_CHECKING(for pthread_setname_np(const char*))
++        AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++                [#include <pthread.h>],
++                [pthread_setname_np("example")])],
++            [AC_MSG_RESULT(yes)
++             AC_DEFINE(HAVE_PTHREAD_SETNAME_NP_WITHOUT_TID,1,
++                [Have function pthread_setname_np(const char*)])],
++            [AC_MSG_RESULT(no)])
+         CPPFLAGS="$glib_save_CPPFLAGS"
+ ])
+ 
+diff --git a/glib/gthread-posix.c b/glib/gthread-posix.c
+index e65e437..245cf76 100644
+--- a/glib/gthread-posix.c
++++ b/glib/gthread-posix.c
+@@ -1175,10 +1175,10 @@ g_system_thread_exit (void)
+ void
+ g_system_thread_set_name (const gchar *name)
+ {
+-#ifdef HAVE_SYS_PRCTL_H
+-#ifdef PR_SET_NAME
+-  prctl (PR_SET_NAME, name, 0, 0, 0, 0);
+-#endif
++#if defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_NAME)
++  prctl (PR_SET_NAME, name, 0, 0, 0, 0); /* on Linux */
++#elif defined(HAVE_PTHREAD_SETNAME_NP_WITHOUT_TID)
++  pthread_setname_np(name); /* on OS X and iOS */
+ #endif
+ }
+ 


### PR DESCRIPTION
I've submitted a patch to glib to enable setting thread names on OS X and iOS (https://bugzilla.gnome.org/show_bug.cgi?id=741807). In the meanwhile, let's get it into our scripts.

Also, this makes glib debuggable. This might add some noise, but also helps debugging and detecting errors early.